### PR TITLE
[Feat] 작년의 오늘 기능 추가

### DIFF
--- a/src/api/diary/diaryApi.ts
+++ b/src/api/diary/diaryApi.ts
@@ -33,14 +33,14 @@ export const fetchMoreDiaries = async (id: number): Promise<DiaryCameFromServer[
   }
 };
 
-export const fetchLastTodayDiary = async (today:string): Promise< DiaryCameFromServer | boolean > => {
+export const sendTodayForLastDiary = async (diaryDate: string): Promise<DiaryCameFromServer | boolean> => {
   try {
-    const { data } = await API.get(`/diary/${today}`);
+    const { data } = await API.post(`/diary/today`, { diaryDate });
     return data;
   } catch (error) {
     throw new Error();
   }
-}
+};
 
 export const writeTodayDiary = async (diaryObject: DiaryToSendToSurver) => {
   try {

--- a/src/components/lastToday.tsx
+++ b/src/components/lastToday.tsx
@@ -1,32 +1,45 @@
-import { diaryStore } from '../store/diary/diaryStore'
+import { useMutation } from '@tanstack/react-query';
+import { sendTodayForLastDiary } from 'api/diary/diaryApi';
+import { datesForStringMaker } from 'utils/util';
+import { DiaryCameFromServer } from 'model/interfaces';
+import { useEffect } from 'react';
+import { renewToken } from 'api/users/usersApi';
 
 import css from '../css/laTod.module.css'
 import NullDiary from './diary/nullDiary';
-import APIS from 'constants/apiConstants';
 import UI from 'constants/uiConstants';
 import DiaryPreview from './diary/list/diaryPreview';
+import APIS from 'constants/apiConstants';
 
-const { DATA: { FETCHING }, NUM_ZERO } = APIS;
 const { TITLE } = UI.LastTodayTsx;
 const { LAST_TODAY_MESSAGE } = UI.NullDiaryTsx;
 
 const LastToday = () => {
+  const [year, month, day] = datesForStringMaker();
 
-  const { diaries } = diaryStore(state => state);
-
-  let content = <p>{FETCHING}</p>;
-
-  if (diaries.length !== NUM_ZERO) {
-    const lastDiary = diaries[NUM_ZERO];
-    content = <DiaryPreview diaryDetails={lastDiary} />
-  } else {
-    content = <NullDiary msg={LAST_TODAY_MESSAGE} />
+  const fetchLastTodayDiary = async () => {
+    await renewToken();
+    mutate();
   }
+
+  const { mutate,data } = useMutation({
+    mutationFn: () => sendTodayForLastDiary(`${year}-${month}-${day}`),
+    mutationKey: [APIS.QUERIES.LAST_TODAY],
+    onError:()=>fetchLastTodayDiary(),
+  })
+
+  useEffect(() => {
+    fetchLastTodayDiary()
+  }, [])
+
+  const content = data
+    ? <DiaryPreview diaryDetails={data as DiaryCameFromServer} />
+    : <NullDiary msg={LAST_TODAY_MESSAGE} />
 
   return (
     <div className={css.total}>
       <h5 className={css.title}>{TITLE}</h5>
-      {content}
+      { content }
     </div>
   )
 }

--- a/src/constants/apiConstants.ts
+++ b/src/constants/apiConstants.ts
@@ -21,6 +21,7 @@ const APIS = {
   QUERIES: {
     DIARIES: "diaries",
     LOGOUT: "logout",
+    LAST_TODAY: "lastToday",
   },
   DATA: {
     FETCHING: "fetching",

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -139,7 +139,7 @@ export const whichDayIsitToday = (): Days => {
   return DAYS_OF_WEEK[new Date().getDay()];
 };
 
-const datesForStringMaker = () => {
+export const datesForStringMaker = () => {
   const now = new Date();
   const methods = DATE_LITERAL_METHODS;
 


### PR DESCRIPTION
- 원래 url의 파리미터로 오늘의 날짜를 보내 조회하려 했지만 보안상 좋지 않다고 판단
- 오늘의 날짜를 바디에 담은 post형식으로 보안성을 높임
- 하지만 Token이 없는 채로 post 요청을 보내 403문제 발생
- 본래 존재하던 Token재발급 함수 실행 후 post 요청을 하도록 수정